### PR TITLE
Update meta.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 827b83ac78e548dace8df5d02583240f4f0fe24a44b86e62a4d503724f7f2cda
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - python >={{ python_min }}
     - pybind11 ~=2.11
     - seaborn-base ~=0.13
-    - cvxpy-base ~=1.5
+    - cvxpy ~=1.5
     - sbtab ~=1.0,>=1.0.8
     - matplotlib-base ~=3.8
     - equilibrator-api ~=0.6.0


### PR DESCRIPTION
changing "cvxpy-base" to "cvxpy" because we need the dependencies on solvers like Clarabel.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
